### PR TITLE
Editorial: move Ryan Kanso to Former Editor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ Level: none
 ED: https://w3c.github.io/contact-picker/
 TR: https://www.w3.org/TR/contact-picker/
 Editor: Peter Beverloo 44819, Google, beverloo@google.com
-Editor: Rayan Kanso 115452, Google, rayankans@google.com
+Former Editor: Rayan Kanso 115452, Google, rayankans@google.com
 Abstract: An API to give one-off access to a user's contact information with full control over the shared data.
 Markup Shorthands: css no, markdown yes
 Indent: 2


### PR DESCRIPTION
Closes #66

Ryan Kanso has stepped down as Editor due to change of affiliation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/contact-picker/pull/67.html" title="Last updated on Oct 10, 2023, 4:05 AM UTC (626aee2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/contact-picker/67/e27a608...626aee2.html" title="Last updated on Oct 10, 2023, 4:05 AM UTC (626aee2)">Diff</a>